### PR TITLE
refactor(): Make the mock-return match the input type

### DIFF
--- a/lib/mock_component.ts
+++ b/lib/mock_component.ts
@@ -1,8 +1,8 @@
-import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Input, Output, Type } from '@angular/core';
 
 declare var Reflect: any;
 
-export function MockComponent(component: any): Component {
+export function MockComponent<TComponent>(component: Type<TComponent>): Type<TComponent> {
   const propertyMetadata = getPropertyMetadata(component);
 
   const options = {
@@ -21,7 +21,7 @@ export function MockComponent(component: any): Component {
     (ComponentMock as any).prototype[output] = new EventEmitter<any>();
   });
 
-  return Component(options as Component)(ComponentMock as any);
+  return Component(options as Component)(ComponentMock as Type<TComponent>);
 }
 
 function isInput(propertyMetadata: any): boolean {


### PR DESCRIPTION
This makes sure when we do:
  `let myMock = MockComponent(MyComponent);`
that the resulting `myMock` is of type `Type<MyComponent>` instead of `any`. This means we don't have to re-cast them when we want to do something with the class type like querying by directive.

We would currently need to do something like this to avoid a compile error (in TS 2.5+):
  `fixture.debugElement.query(By.directive(myMock as Type<any>))`

With this change, we don't need the re-cast:
  `fixture.debugElement.query(By.directive(myMock))`